### PR TITLE
Fixes for building RPMs since Centos 7.3 released

### DIFF
--- a/packaging/docker/buildonly-lustre-client/Dockerfile
+++ b/packaging/docker/buildonly-lustre-client/Dockerfile
@@ -7,4 +7,4 @@ ARG package_url
 
 RUN echo -e "[${REPO_NAME}]\nname=${REPO_NAME}\ngpgcheck=0\nbaseurl=${package_url}\n" | sed -e 's/,/%2C/g' > /etc/yum.repos.d/${REPO_NAME}.repo \
 	&& unset no_proxy NO_PROXY \
-	&& yum install -y lustre-client
+	&& yum install --enablerepo=C7.2.1511-updates -y lustre-client

--- a/packaging/docker/buildonly-lustre-client/Makefile
+++ b/packaging/docker/buildonly-lustre-client/Makefile
@@ -7,7 +7,7 @@ LUSTRE_BUILD ?= lastSuccessfulBuild
 CLIENT_PACKAGE ?= lustre-client
 
 PACKAGE_URL := $(BUILDER_URL)/job/$(LUSTRE_JOB)/arch=x86_64,build_type=client,distro=el7,ib_stack=inkernel/$(LUSTRE_BUILD)
-CLIENT_VERSION := $(shell curl -sf $(PACKAGE_URL)/api/json | python -c 'import sys, json, re; pkg=[a for a in json.load(sys.stdin)["artifacts"] if re.search(r"$(CLIENT_PACKAGE)-\d+.*\.rpm", a["fileName"])][0]["fileName"]; print re.sub(r"$(CLIENT_PACKAGE)-(.*)\.x86_64\.x86_64\.rpm",r"\1",pkg)')
+CLIENT_VERSION := $(shell curl -sf $(PACKAGE_URL)/api/json | python -c 'import sys, json, re; pkg=[a for a in json.load(sys.stdin)["artifacts"] if re.search(r"$(CLIENT_PACKAGE)-\d+.*\.rpm", a["fileName"])][0]["fileName"]; print(re.sub(r"$(CLIENT_PACKAGE)-(.*)\.x86_64\.x86_64\.rpm",r"\1",pkg))')
 IMAGE := $(shell latest=$$(docker images | awk "/$(REPO).*$(CLIENT_VERSION)/ {print \$$2}"); if [ "$$latest" == $(CLIENT_VERSION) ]; then true; else echo $(REPO)/$(CLIENT_VERSION); fi)
 
 $(CLIENT_VERSION): $(IMAGE)


### PR DESCRIPTION
Hello,
I had to make these two changes to build the RPMs on a fresh checkout.

The python change in 6f9b726 is only relevant because my distro ships python3 as default python - this is less relevant to most major distros, but I think the syntax is backwards compatible to python 2.7

The change in 55041d6 is needed since Centos 7.3 is released as the required kernel package is no longer available in the latest base/updates repos, so it is required to enable the Vault repo for 7.2.1511.

Just thought I send this back in case it's useful.
Thanks,
Matt Raso-Barnett
Uni of Cam